### PR TITLE
Fix to work with newer version of Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ group :development, :test do
   gem 'simplecov-rcov'
   gem 'yarjuf'
   gem 'require_all'
+  gem 'test-unit'
   gem 'byebug'
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -58,9 +58,8 @@ module Spree
 
             line_item_personalization.price = calculator.try(:preferred_amount)
             line_item_personalization.currency = calculator.try(:preferred_currency)
-            line_item_personalization.save
           else
-            line_item_personalization.destroy
+            self.personalizations.destroy(line_item_personalization)
           end
         end
       else


### PR DESCRIPTION
The rspec is broken due to newer version of Rails. This PR address those issues:

1. Add `test-unit` to the Gemfile.
2. Destroying a record doesn't take it out of the activerecord collection anymore in newer version of Rails.

This PR also fix an existing issue where it saves the record in a before_validation hook which would triger the hook itself again (inefficient code).
