### PR TITLE
Fix a typo that could be a time bomb

### DIFF
--- a/app/models/spree/option_value_decorator.rb
+++ b/app/models/spree/option_value_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   OptionValue.class_eval do
-    has_many :option_value_product_personalizations, dependent: :destroy, inverse_of: :option_type
+    has_many :option_value_product_personalizations, dependent: :destroy, inverse_of: :option_value
     has_many :product_personalizations, through: :option_value_product_personalizations
   end
 end


### PR DESCRIPTION
Discover this while working on an Iris. It prevent an option value from being deleted. It may has other effect as well. Fortunately it doesn't seem to affect our app yet because this typo has been around for a while. But better fix the time bomb now before it blows up.